### PR TITLE
Live 2D field plots for all ocean variables

### DIFF
--- a/docs/2d-fields-plot-design.md
+++ b/docs/2d-fields-plot-design.md
@@ -1,0 +1,135 @@
+# 2D spatial field plots for all variables — locked design
+
+Live 2D spatial plots (horizontal maps + vertical sections) for **every** enabled
+model variable, updating live as a run progresses — generalizing the existing
+single SST heatmap. Derived from Andy's meeting notes + a design interview
+(2026-07-24). Status: **design locked, implementation not started.**
+
+## Goal / UX
+
+A third tab in the Plots page alongside "Time series" and the SST "Heatmap":
+
+- **Horizontal slice** — lon x lat map at a chosen **depth level** (generalizes
+  the SST heatmap to any variable, any depth).
+- **Vertical slice** — lon x depth cross-section at a chosen **latitude**
+  (surface at top, land / below-seafloor masked).
+- Dropdowns: **variable**, **slice type**, and **depth (horizontal) / latitude
+  (vertical)**. Populated automatically from run metadata, no hard-coded list.
+
+## Core architectural decision (Q1 = A, reuse)
+
+Reuse the proven **Fortran-writes-small-netCDF -> Python backend reads it ->
+serves tiny JSON -> frontend polls on a change-token** pattern that already backs
+the live SST heatmap. Do **not** have Fortran write many ASCII slice files
+(Andy's literal note #6) — that path breaks on the default sparse timeslice
+schedule and causes a file explosion.
+
+### Why not just read the existing `fields_biogem_3d.nc`
+
+That archival file is written on the sparse, log-spaced `save_timeslice.dat`
+schedule (default: `0.5, 1.5, 4.5, 9.5, 19.5, 49.5, ...`). A short teaching run
+writes only ~3-5 records, at non-annual times. Reading it would produce almost
+**no live frames** on a normal run. The cadence is also a per-run user-config
+choice we do not control.
+
+### The mechanism: generalize the SST snapshot
+
+Add one new writer modeled exactly on `sub_data_netCDF_temp_snapshot`
+(`src/biogem/biogem_data_netCDF.f90:149`), which already reads **live in-memory
+arrays** (independent of `save_timeslice.dat`) and writes atomically:
+
+- **`biogem_fields_snapshot.nc`** — a single-record file, **overwritten** each
+  seasonal quarter (not accumulated -> stays ~1 MB), atomic `.tmp` + rename,
+  carrying the `quarter_index` global attr as the frontend change-token.
+- Written **at run init, zero-filled**, defining **every enabled variable + all
+  axes** (lon, lat, zt/depth). This init file **doubles as the dropdown
+  metadata** — it folds Andy's separate "dummy netCDF" (note #5) into the same
+  mechanism, so there is **one** writer instead of two.
+- Reads the live in-memory field arrays (like the SST writer reads `ocn(io_T)`),
+  so it is **immune to the sparse-timeslice trap** and works on short runs.
+
+## Locked decisions
+
+| # | Decision | Choice |
+|---|----------|--------|
+| Q1 | Data path | **A** — reuse netCDF -> backend-read -> JSON (not Fortran ASCII files) |
+| Q2 | Cadence | **annual mean, one frame per model year** (revised per Andy — see below; was seasonal in the first cut) |
+| Q3 | Variables | **(a)** all enabled fields, **auto-discovered** (same loops as fields netCDF), readable `long_name` labels |
+| Q4 | Color scale | **(b2)** whole-run **expanding** range — frontend tracks running min/max per variable across all frames seen; never clips, no per-variable curation |
+| Q5 | Vertical slice | lon x depth section at a chosen **latitude** (reversed depth axis, surface top). Zonal-mean sections deferred |
+| Q6 | 2D-only variables | **auto-detect** dimensionality from the snapshot; for a 2D variable hide the depth dropdown and disable the vertical tab |
+
+## Implementation details (locked)
+
+**Fortran** (`src/biogem/`)
+- New snapshot writer generalizing `sub_data_netCDF_temp_snapshot` to loop over
+  all enabled variables (2D + 3D), reusing the enable flags / tracer loops used
+  by the fields netCDF savers (`ctrl_data_save_slice_*`, `n_l_ocn`, etc.).
+- Init call writes the file zero-filled with full variable + axis definitions.
+- Per-quarter call overwrites with current in-memory values; atomic write; bump
+  `quarter_index`. Wire the trigger like the SST snapshot
+  (`src/carrotcake.f90:409` -> `genie_loop_wrappers.f90:344`).
+- Do **not** hardcode grid dims — read `n_i/n_j/n_k` as the existing code does
+  (`biogem.f90:60-62`); depth levels vary by config (default 8, some 16).
+
+**Backend** (`tools/REST.py`)
+- Metadata endpoint: list variables (`long_name`, units, 2D-vs-3D flag) + axis
+  arrays (lon, lat, depth) read from `biogem_fields_snapshot.nc`.
+- Data endpoint: return **one variable's full array per request** (~<1 MB, not
+  all ~30 at once) + axes + `token`.
+- Reuse `_resolve_read_path` / `find_plot_data_path` and the
+  `nc.Dataset` + `.tolist()` masked-array -> `null` shaping from
+  `/get-temp-snapshot` (`REST.py:1209`). Masked land / below-bathymetry -> null.
+
+**Frontend** (`cupcake-frontend/src/components/Plots.js`)
+- Add a third `activeTab` value + button; conditional render a new
+  `FieldsPlot` component.
+- Chained dropdowns (variable -> slice type -> depth/latitude), following the
+  existing timeseries chained-`<select>` pattern.
+- Fetch the selected variable's full 3D array **once per token**; do depth-level
+  and latitude slicing **client-side in JS** -> instant dropdown response, one
+  endpoint, less backend load. Maintain per-variable running min/max (Q4 b2).
+- Reuse the generalized `TempHeatmap` Plotly block; **drop `scaleanchor` /
+  `aspectRatio`** for vertical sections and use a reversed depth y-axis; keep the
+  token + 2.5 s polling while the job is in an active state.
+
+## Deliverables (mapped to Andy's action items)
+
+1. **Fortran** — the unified `biogem_fields_snapshot.nc` writer (folds Andy #5
+   dummy netCDF + #6 slice mechanism into one).
+2. **Backend** — metadata + single-variable data endpoints.
+3. **Frontend** — 2D Fields tab: horizontal/vertical slice types, metadata-driven
+   dropdowns, Plotly render.
+
+## To verify during implementation
+
+- Actual per-config depth levels (`n_k`: default 8, some configs 16) — read from
+  the snapshot axes, never hardcode.
+- Snapshot file size with all enabled 3D vars at the run's real config
+  (~1 MB expected; confirm the 4x/year overwrite + 2 s sync stays cheap).
+- Whether the auto-discovered dropdown is too noisy for students (obscure
+  diagnostics) — filtering is a later frontend-only change if so.
+
+## Andy's feedback (2026-07-24) — incorporated
+
+- **Annual averages, not seasonal.** Andy ran a 10-yr seasonal test
+  (`modern.OCEAN16` / `.SPIN`) and counted 17 frames, not 40 — seasonal isn't
+  reliably 4x/yr, and an under-sampled seasonal signal on a trend aliases. He
+  asked for **annual averages**: guarantees >=1 frame/year, never skips a year.
+  → Reworked the writer to accumulate `ocn()` every timestep and publish one
+  annual-mean frame per year (`sub_fields_snapshot_update` at each year rollover;
+  `sub_fields_snapshot_finalize` in `end_biogem` flushes the final partial year).
+  Token = the model **year**; the init/zero file uses year -1 so the frontend
+  waits for the first real frame.
+- **"Year: xxx" label** above the plot so users see run progress. → Added
+  (backend returns `year`; frontend shows it).
+- **Do lon-lat (horizontal) first.** Both slice types are built; horizontal is
+  the focus for the first live test, vertical is a bonus.
+- Confirmed: as netCDF; all variables auto-discovered / no hard-coded list; three
+  tabs; read variables once the first slice is written (we do it at init).
+
+## Still to tell Andy in the next email
+
+- **Isotope tracers are skipped in v1** (delta-conversion sentinel would corrupt
+  the auto colour scale) — easy follow-up.
+- Possible future: option to show a student-friendly subset vs. all variables.

--- a/src/biogem/biogem.f90
+++ b/src/biogem/biogem.f90
@@ -490,6 +490,11 @@ CONTAINS
           ncout3dsig_ntrec = 0
        end if
     ENDIF
+    ! zero-filled 3D fields snapshot: exists from run start so the frontend can read
+    ! variable names + axes to build its 2D-plot dropdowns before any data is produced.
+    ! year = -1 marks it as "not a real frame"; annual means overwrite it as the run
+    ! progresses (sub_fields_snapshot_update) and end_biogem flushes the final year.
+    call sub_data_netCDF_fields_snapshot(TRIM(par_outdir_name)//'biogem_fields_snapshot.nc', -1, .TRUE.)
 
     ! *** load restart information ***
     IF (ctrl_continuing .OR. gui_restart) then
@@ -3181,6 +3186,10 @@ CONTAINS
     WRITE(unit=out,fmt='(i6)') ncout2d_ntrec,ncout3d_ntrec
     close(unit=out)
 
+    ! flush the final (partial) year of the live 2D-fields snapshot so the last
+    ! year is never skipped (annual-mean feature)
+    call sub_fields_snapshot_finalize(TRIM(par_outdir_name)//'biogem_fields_snapshot.nc')
+
     ! ---------------------------------------------------------- !
     !  DEALLOCATE ARRAYS
     !- --------------------------------------------------------- !
@@ -3306,6 +3315,11 @@ CONTAINS
        loc_filename = TRIM(par_outdir_name) // 'biogem_temp_snapshot.nc'
        CALL sub_data_netCDF_temp_snapshot(loc_filename, loc_yr, loc_qtr)
     END IF
+    ! 3D fields snapshot for the general 2D-plot feature: accumulate every time-step
+    ! and publish an annual mean at each year boundary (avoids the seasonal
+    ! under-sampling / aliasing Andy flagged); the final year is flushed in end_biogem.
+    loc_filename = TRIM(par_outdir_name) // 'biogem_fields_snapshot.nc'
+    CALL sub_fields_snapshot_update(loc_filename, loc_yr)
   END SUBROUTINE biogem_save_temp_snapshot
   ! ******************************************************************************************************************************** !
 

--- a/src/biogem/biogem_data_netCDF.f90
+++ b/src/biogem/biogem_data_netCDF.f90
@@ -14,6 +14,18 @@ MODULE biogem_data_netCDF
   IMPLICIT NONE
   SAVE
 
+  ! ---- Annual-average accumulator for the live 2D-fields snapshot ----------- !
+  ! biogem_fields_snapshot.nc holds ONE annual-mean frame per model year. Andy's
+  ! call: a seasonal (4x/yr) snapshot under-samples and aliases a seasonal signal
+  ! riding a trend; an annual average guarantees >=1 frame per year and never
+  ! skips one. We sum ocn() every timestep here and divide by the sample count at
+  ! the year boundary (sub_fields_snapshot_update), publishing the completed
+  ! year's mean; sub_fields_snapshot_finalize flushes the final partial year at
+  ! run end. Sub-seafloor cells are masked out on write.
+  real, allocatable :: fields_snap_accum(:,:,:,:)   ! running sum of ocn over the current year
+  integer :: fields_snap_count = 0                  ! samples accumulated in the current year
+  integer :: fields_snap_year  = -HUGE(1)           ! current year bucket; -HUGE => not started
+
 
 CONTAINS
 
@@ -233,6 +245,223 @@ CONTAINS
     ! -------------------------------------------------------- !
   END SUBROUTINE sub_data_netCDF_temp_snapshot
   ! ****************************************************************************************************************************** !
+
+
+  ! ****************************************************************************************************************************** !
+  ! SAVE 3D FIELDS SNAPSHOT (all selected ocean tracers, overwritten each call)
+  !
+  ! Generalises sub_data_netCDF_temp_snapshot from a single surface field to every
+  ! selected ocean tracer over the full water column, so the frontend can plot live
+  ! horizontal maps (at any depth level) and vertical sections (at any latitude) for
+  ! any variable. It writes ONE annual-mean frame per model year (Andy's call vs. a
+  ! seasonal snapshot -- see the module-level accumulator notes): the mean comes from
+  ! fields_snap_accum / fields_snap_count, built by sub_fields_snapshot_update. Like
+  ! the temperature snapshot it writes a single record to a .tmp file then atomically
+  ! renames, and carries the model year as the frontend change token + "Year" label.
+  !
+  ! When called with dum_is_init = .TRUE. (once, at model init) the data is written
+  ! all-zero with year = -1: that file exists purely so the frontend can read variable
+  ! names + axes and build its dropdowns before any real data has been produced (and
+  ! the -1 year keeps the frontend from treating it as a real frame).
+  !
+  ! v1 scope: ocean tracers of type 0 and 1 (temperature, salinity, and the scalar
+  ! biogeochem concentrations). Isotope tracers (ocn_type in n_itype_min:n_itype_max)
+  ! are deliberately skipped for now -- they need delta conversion whose zero-bulk
+  ! fallback emits a sentinel that would corrupt the frontend's auto-scaled colour
+  ! range; adding them is a later, self-contained extension.
+  ! ****************************************************************************************************************************** !
+  SUBROUTINE sub_data_netCDF_fields_snapshot(dum_name, dum_year, dum_is_init)
+    ! -------------------------------------------------------- !
+    ! DUMMY ARGUMENTS
+    ! -------------------------------------------------------- !
+    character(LEN=*), INTENT(IN) :: dum_name      ! final output file path
+    INTEGER,          INTENT(IN) :: dum_year      ! model year for this frame (token + label); -1 at init
+    LOGICAL,          INTENT(IN) :: dum_is_init   ! .true. => zero-filled metadata file (no data yet)
+    ! -------------------------------------------------------- !
+    ! DEFINE LOCAL VARIABLES
+    ! -------------------------------------------------------- !
+    integer :: l, io, i, j, k
+    integer :: loc_iou, loc_ntrec
+    integer :: loc_id_time, loc_id_lonm, loc_id_latm, loc_id_zt
+    integer :: loc_rename_stat
+    integer, dimension(1) :: loc_it_1
+    integer, dimension(4) :: loc_it_4
+    character(127) :: loc_title, loc_timunit
+    character(8)   :: loc_string_year
+    character(32)  :: loc_year_str
+    character(255) :: loc_name_tmp
+    real :: loc_c0, loc_c1, loc_rcount
+    real, dimension(n_i, n_j, n_k) :: loc_ijk, loc_mask
+    ! -------------------------------------------------------- !
+    ! INITIALIZE LOCAL VARIABLES
+    ! -------------------------------------------------------- !
+    loc_c0 = 0.0 ; loc_c1 = 1.0
+    loc_ijk  = 0.0
+    loc_mask = phys_ocn(ipo_mask_ocn, :, :, :)
+    ! annual mean = (sum of ocn over the year) / (number of samples); the init
+    ! call carries no samples and writes all-zero, so guard the reciprocal
+    if (fields_snap_count > 0) then
+       loc_rcount = 1.0 / real(fields_snap_count)
+    else
+       loc_rcount = 0.0
+    end if
+    ! write to a temporary file first, then atomically rename, so a concurrent
+    ! reader (REST endpoint) never sees a partially-written file
+    loc_name_tmp = TRIM(dum_name) // '.tmp'
+    ! -------------------------------------------------------- !
+    ! DEFINE FILE STRUCTURE
+    ! -------------------------------------------------------- !
+    call sub_opennew(loc_name_tmp, loc_iou)
+    call sub_redef(loc_iou)
+    ! global attributes
+    loc_string_year = fun_conv_num_char_n(8, dum_year)
+    loc_title   = 'BIOGEM 3D fields annual-mean snapshot @ year ' // loc_string_year
+    loc_timunit = 'Year'
+    call sub_putglobal(loc_iou, dum_name, loc_title, string_ncrunid, loc_timunit)
+    ! model year: doubles as the frontend change token AND the "Year: xxx" label.
+    ! The init file writes -1 so the frontend waits for the first real annual frame.
+    write(loc_year_str, '(I0)') dum_year
+    call sub_putatttext('global', loc_iou, 'year', trim(loc_year_str))
+    ! dimensions: time (unlimited, so sub_putvar3d_g can index a record), lon, lat, zt
+    call sub_defdim('time', loc_iou, const_integer_zero, loc_id_time)
+    call sub_defdim('lon',  loc_iou, n_i, loc_id_lonm)
+    call sub_defdim('lat',  loc_iou, n_j, loc_id_latm)
+    call sub_defdim('zt',   loc_iou, n_k, loc_id_zt)
+    ! axis variables (sub_adddef_netcdf below looks these up by name)
+    loc_it_1(1) = loc_id_time
+    call sub_defvar('time', loc_iou, 1, loc_it_1, loc_c0, loc_c0, 'T', 'D', &
+         & 'Year', 'time', trim(loc_timunit))
+    call sub_defvar('year', loc_iou, 1, loc_it_1, loc_c0, loc_c0, ' ', 'F', 'year', ' ', ' ')
+    loc_it_1(1) = loc_id_lonm
+    call sub_defvar('lon', loc_iou, 1, loc_it_1, loc_c0, loc_c0, 'X', 'D', &
+         & 'longitude of the t grid', 'longitude', 'degrees_east')
+    loc_it_1(1) = loc_id_latm
+    call sub_defvar('lat', loc_iou, 1, loc_it_1, loc_c0, loc_c0, 'Y', 'D', &
+         & 'latitude of the t grid', 'latitude', 'degrees_north')
+    loc_it_1(1) = loc_id_zt
+    call sub_defvar('zt', loc_iou, 1, loc_it_1, loc_c0, loc_c0, 'Z', 'D', &
+         & 'z-level mid depth', 'depth', 'm')
+    ! define each selected tracer as a 4-D field (lon, lat, zt, time) using the
+    ! REAL dimension ids. NB: do not use sub_adddef_netcdf here -- it resolves dims
+    ! via inq_varid and only works when varid==dimid, which our axis layout breaks.
+    loc_it_4(1) = loc_id_lonm ; loc_it_4(2) = loc_id_latm
+    loc_it_4(3) = loc_id_zt   ; loc_it_4(4) = loc_id_time
+    DO l = 1, n_l_ocn
+       io = conv_iselected_io(l)
+       SELECT CASE (ocn_type(io))
+       CASE (0, 1)
+          call sub_defvar('ocn_'//trim(string_ocn(io)), loc_iou, 4, loc_it_4, &
+               & ocn_mima(l, 1), ocn_mima(l, 2), ' ', 'F', &
+               & trim(string_ocn_tlname(l)), ' ', trim(string_ocn_unit(l)))
+       END SELECT
+    END DO
+    call sub_enddef(loc_iou)
+    call sub_sync(loc_iou)
+    ! -------------------------------------------------------- !
+    ! WRITE AXIS DATA (record 1)
+    ! -------------------------------------------------------- !
+    loc_ntrec = 1
+    call sub_putvars ('time', loc_iou, loc_ntrec, real(dum_year), loc_c1, loc_c0)
+    call sub_putvarIs('year', loc_iou, loc_ntrec, dum_year, loc_c1, loc_c0)
+    call sub_putvar1d('lon', loc_iou, n_i, loc_ntrec, n_i, phys_ocn(ipo_lon, :, 1, 1), loc_c1, loc_c0)
+    call sub_putvar1d('lat', loc_iou, n_j, loc_ntrec, n_j, phys_ocn(ipo_lat, 1, :, 1), loc_c1, loc_c0)
+    ! zt reversed (surface-first) to match sub_putvar3d_g's k-reversal below
+    call sub_putvar1d('zt', loc_iou, n_k, loc_ntrec, n_k, phys_ocn(ipo_Dmid, 1, 1, n_k:1:-1), loc_c1, loc_c0)
+    ! -------------------------------------------------------- !
+    ! WRITE EACH SELECTED OCEAN TRACER AS A 3D FIELD (annual mean)
+    ! -------------------------------------------------------- !
+    DO l = 1, n_l_ocn
+       io = conv_iselected_io(l)
+       ! v1: scalar physical / biogeochem tracers only (skip isotopes -- see header)
+       SELECT CASE (ocn_type(io))
+       CASE (0, 1)
+          loc_ijk(:, :, :) = const_real_zero
+          if (.NOT. dum_is_init) then
+             ! annual mean over the water column (k1..n_k); sub-seafloor cells stay
+             ! zero and are masked out by loc_mask on write
+             DO i = 1, n_i
+                DO j = 1, n_j
+                   DO k = goldstein_k1(i, j), n_k
+                      if ((ocn_type(io) == 0) .AND. (io == io_T)) then
+                         loc_ijk(i, j, k) = fields_snap_accum(io, i, j, k) * loc_rcount - const_zeroC  ! K -> degrees C
+                      else
+                         loc_ijk(i, j, k) = fields_snap_accum(io, i, j, k) * loc_rcount
+                      end if
+                   end do
+                end do
+             end do
+          end if
+          ! variable already defined up front; just write this record's data
+          call sub_putvar3d_g('ocn_'//trim(string_ocn(io)), loc_iou, n_i, n_j, n_k, &
+               & loc_ntrec, loc_ijk(:, :, :), loc_mask)
+       END SELECT
+    END DO
+    ! -------------------------------------------------------- !
+    ! CLOSE + ATOMIC PUBLISH
+    ! -------------------------------------------------------- !
+    call sub_closefile(loc_iou)
+    call rename(trim(loc_name_tmp), trim(dum_name), loc_rename_stat)
+    if (loc_rename_stat /= 0) then
+       print *, 'WARNING: fields snapshot rename failed, status =', loc_rename_stat
+    end if
+    ! -------------------------------------------------------- !
+    ! END
+    ! -------------------------------------------------------- !
+  END SUBROUTINE sub_data_netCDF_fields_snapshot
+  ! ****************************************************************************************************************************** !
+
+
+  ! ****************************************************************************************************************************** !
+  ! ACCUMULATE + PUBLISH THE ANNUAL-MEAN FIELDS SNAPSHOT
+  !
+  ! Called every BIOGEM time-step. Sums the live ocn() array into a year buffer;
+  ! when the integer model year advances, publishes the just-completed year's mean
+  ! (via sub_data_netCDF_fields_snapshot) and resets the buffer for the new year.
+  ! ****************************************************************************************************************************** !
+  SUBROUTINE sub_fields_snapshot_update(dum_name, dum_yr)
+    character(LEN=*), INTENT(IN) :: dum_name   ! output file path
+    REAL,             INTENT(IN) :: dum_yr     ! current model year
+    integer :: loc_yr_idx
+    ! allocate the year buffer on first use (sized to the full ocn tracer array)
+    if (.NOT. allocated(fields_snap_accum)) then
+       allocate(fields_snap_accum(n_ocn, n_i, n_j, n_k))
+       fields_snap_accum = 0.0
+       fields_snap_count = 0
+    end if
+    loc_yr_idx = INT(dum_yr)
+    if (fields_snap_year == -HUGE(1)) then
+       fields_snap_year = loc_yr_idx                       ! first call: open the first year's bucket
+    else if (loc_yr_idx /= fields_snap_year) then
+       ! year rolled over: publish the completed year's annual mean, then reset
+       if (fields_snap_count > 0) &
+            & call sub_data_netCDF_fields_snapshot(dum_name, fields_snap_year, .FALSE.)
+       fields_snap_accum = 0.0
+       fields_snap_count = 0
+       fields_snap_year  = loc_yr_idx
+    end if
+    ! accumulate this time-step into the current year's bucket
+    fields_snap_accum(:, :, :, :) = fields_snap_accum(:, :, :, :) + ocn(:, :, :, :)
+    fields_snap_count = fields_snap_count + 1
+  END SUBROUTINE sub_fields_snapshot_update
+  ! ****************************************************************************************************************************** !
+
+
+  ! ****************************************************************************************************************************** !
+  ! FLUSH THE FINAL (PARTIAL) YEAR AT RUN END
+  !
+  ! The rollover in sub_fields_snapshot_update never fires for the last year, so
+  ! call this once from end_biogem to publish that year's mean-so-far. Guarantees
+  ! the final year is never skipped (Andy: "never skip a year").
+  ! ****************************************************************************************************************************** !
+  SUBROUTINE sub_fields_snapshot_finalize(dum_name)
+    character(LEN=*), INTENT(IN) :: dum_name   ! output file path
+    if (allocated(fields_snap_accum) .AND. (fields_snap_count > 0)) then
+       call sub_data_netCDF_fields_snapshot(dum_name, fields_snap_year, .FALSE.)
+       fields_snap_count = 0
+    end if
+  END SUBROUTINE sub_fields_snapshot_finalize
+  ! ****************************************************************************************************************************** !
+
 
   ! ****************************************************************************************************************************** !
   ! INITIALIZE netCDF

--- a/tools/REST.py
+++ b/tools/REST.py
@@ -1253,6 +1253,143 @@ async def get_temp_snapshot(job_name: str, current_user=Depends(get_current_user
 
 
 # =============================================================================
+# 3D fields snapshot (live 2D plots for all variables)
+# =============================================================================
+#
+# The Fortran model writes biogem_fields_snapshot.nc: a single-record netCDF
+# holding every selected ocean tracer over the full water column, written
+# zero-filled at run start (for metadata) then overwritten with live values each
+# season (same cadence + quarter_index token as the SST snapshot). The frontend
+# fetches the metadata once to build its dropdowns, then polls one variable's
+# full array and slices it (depth level / latitude) client-side.
+
+_FIELDS_SNAPSHOT_FILE = "biogem_fields_snapshot.nc"
+
+
+def _open_fields_snapshot(current_user, job_name):
+    """Resolve + open the fields snapshot for a job. Returns an open
+    netCDF4.Dataset (caller must close) or raises HTTPException(404)."""
+    job_path = _resolve_read_path(current_user, job_name)
+    try:
+        plot_data_path = find_plot_data_path(job_path)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    snapshot_path = os.path.join(plot_data_path, _FIELDS_SNAPSHOT_FILE)
+    if not os.path.isfile(snapshot_path):
+        raise HTTPException(
+            status_code=404, detail="Fields snapshot not yet available"
+        )
+    try:
+        return nc.Dataset(snapshot_path, "r")
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500, detail=f"Error opening fields snapshot: {exc}"
+        )
+
+
+def _is_field_var(ds, name):
+    """A plottable field is any variable whose dims include both lon and lat
+    (excludes the lon/lat/zt/time/year coordinate variables)."""
+    dims = ds.variables[name].dimensions
+    return ("lon" in dims) and ("lat" in dims)
+
+
+def _snapshot_token(ds):
+    # The fields snapshot stamps the model year as its change token: one annual-mean
+    # frame per year, so a new year == a new frame. The init/zero file carries -1.
+    try:
+        return int(ds.getncattr("year"))
+    except (AttributeError, ValueError):
+        return -1
+
+
+@app.get("/get-fields-meta/{job_name}")
+async def get_fields_meta(job_name: str, current_user=Depends(get_current_user)):
+    """
+    Metadata for the 2D-field plots: the lon/lat/depth axes and the list of
+    plottable variables (name, human-readable label, units, and whether the
+    variable has a depth dimension). Available from run start because the model
+    writes a zero-filled snapshot at init, so the frontend can build its
+    dropdowns before any data exists.
+    """
+    ds = _open_fields_snapshot(current_user, job_name)
+    try:
+        lon = ds.variables["lon"][:].tolist()
+        lat = ds.variables["lat"][:].tolist()
+        depth = ds.variables["zt"][:].tolist() if "zt" in ds.variables else []
+        variables = []
+        for name in ds.variables:
+            if not _is_field_var(ds, name):
+                continue
+            var = ds.variables[name]
+            variables.append(
+                {
+                    "name": name,
+                    "label": getattr(var, "long_name", name).strip() or name,
+                    "units": getattr(var, "units", "").strip(),
+                    "is3d": "zt" in var.dimensions,
+                }
+            )
+        variables.sort(key=lambda v: v["label"].lower())
+        token = _snapshot_token(ds)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500, detail=f"Error reading fields metadata: {exc}"
+        )
+    finally:
+        ds.close()
+
+    return {
+        "token": token,
+        "lon": lon,
+        "lat": lat,
+        "depth": depth,
+        "variables": variables,
+    }
+
+
+@app.get("/get-field-snapshot/{job_name}/{var_name}")
+async def get_field_snapshot(
+    job_name: str, var_name: str, current_user=Depends(get_current_user)
+):
+    """
+    The full array for a single variable plus the change token. For a 3D
+    variable this is depth x lat x lon (surface-first depth order); for a 2D
+    variable it is lat x lon. Masked land / below-seafloor cells are null. The
+    frontend does all depth-level / latitude slicing on this array client-side,
+    so switching slices needs no extra request.
+    """
+    ds = _open_fields_snapshot(current_user, job_name)
+    try:
+        if var_name not in ds.variables or not _is_field_var(ds, var_name):
+            raise HTTPException(
+                status_code=404, detail=f"Unknown field variable: {var_name}"
+            )
+        var = ds.variables[var_name]
+        is3d = "zt" in var.dimensions
+        # Drop the leading unit-length time axis. netCDF4 returns Fortran
+        # (lon,lat,zt,time) as (time,zt,lat,lon); (lon,lat,time) as (time,lat,lon).
+        # .tolist() turns masked (land / sub-seafloor) cells into None.
+        values = var[0].tolist()
+        token = _snapshot_token(ds)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500, detail=f"Error reading field '{var_name}': {exc}"
+        )
+    finally:
+        ds.close()
+
+    # token == the model year of this annual-mean frame; the frontend uses it both
+    # to detect a new frame and to show the "Year: xxx" label.
+    return {"token": token, "year": token, "name": var_name, "is3d": is3d, "values": values}
+
+
+# =============================================================================
 # Download job zip
 # =============================================================================
 


### PR DESCRIPTION
Adds live 2D spatial plots of **every enabled ocean variable** (not just the single SST heatmap), viewable as the run progresses.

**BIOGEM (Fortran) — the main change:**
- New `biogem_fields_snapshot.nc` writer that generalises the existing SST snapshot to every selected ocean tracer over the full water column.
- Writes **one annual-mean frame per model year** (Andy's call — seasonal under-samples and aliases). Accumulates the live in-memory `ocn()` array every timestep and publishes the mean at each year rollover; the final year is flushed at `end_biogem`.
- Reading live memory makes it **independent of the sparse `save_timeslice` schedule**, so it works on short runs.
- A zero-filled metadata file is written at init so the frontend can build its menus before any data exists.

**Backend:** two endpoints (`/get-fields-meta`, `/get-field-snapshot/{var}`) reusing the SST netCDF read pattern; land masked to null; model year as the change token.

Detailed inline comments below walk through the Fortran mechanism specifically.

_v1 scope note: isotope tracers are deliberately excluded (their delta conversion emits a sentinel that would corrupt the auto colour scale) — a small, self-contained follow-up._

🤖 Generated with [Claude Code](https://claude.com/claude-code)